### PR TITLE
Fix for shard allocation flaw

### DIFF
--- a/src/test/scala/com/whitepages/cloudmanager/OperationsTest.scala
+++ b/src/test/scala/com/whitepages/cloudmanager/OperationsTest.scala
@@ -32,7 +32,7 @@ import scala.collection.JavaConverters._
 @ThreadLeakScope(Scope.NONE)  // disable the usual lucene test case leak checking
 class OperationsTest extends ManagerTestBase {
   override def managerTest() = {
- val clusterManager = new ClusterManager(cloudClient)
+    val clusterManager = new ClusterManager(cloudClient)
 
     // get a clean slate - cluster with no collections
     assertTrue(Operation(Seq(DeleteCollection(oldCollectionName))).execute(cloudClient))


### PR DESCRIPTION
**The Issue**
Suppose we have 4 shards and want 16 total replicas across 8 nodes (so 2 shards/node)
We drop nodes in where there’s space, in no particular order, and at some point reach a state like this:
`| 1  | 1 | 1 | 2 | 2 | 2 | 2 | 3 |`
`| 4 | 4 | _ | 3 | 4 | 4 | 3 | 3 |`
We need one more "1" shard, but we can’t fit it in the open slot because there’s already a 1 in that node.

**The Effects**
Previously, the participation allocator would put the remaining shard 1 onto another node, yielding an underfilled node and an overfilled node.
With these changes, if the first assignment attempt fails to evenly distribute nodes, it will recursively backtrack in search of an evenly-distributed assignment, and return an error if unable to find one.

The provided tests seem capable of only allocating a small local cluster, so manual testing on a production-scale cluster is recommended prior to merge.